### PR TITLE
prov filters with tsv-based prov

### DIFF
--- a/scoring.R
+++ b/scoring.R
@@ -2,117 +2,141 @@
 
 library(aws.s3)
 library(neon4cast)
-
+library(magrittr)
 #source("R/score_it.R")
-source("R/download_bucket.R")
 source("../neon4cast-shared-utilities/publish.R")
 
-## We'll read the files over the AWS API, though we could als o read them directly from disk on the serve
 dir.create("scores")
 Sys.setenv("AWS_DEFAULT_REGION" = "data",
            "AWS_S3_ENDPOINT" = "ecoforecast.org")
-targets <- download_bucket("targets")
-forecasts <- download_bucket("forecasts")
-submissions <- download_bucket("submissions")
+
+## Note: sync also requires auth credentials even to download from public bucket
+suppressMessages({
+aws.s3::s3sync("forecasts", bucket= "forecasts",  direction= "download", verbose= FALSE)
+aws.s3::s3sync("targets", "targets", direction= "download", FALSE)
+})
 
 
+## List the downloaded files
+targets <- fs::dir_ls("targets", recurse = TRUE, type = "file")
+forecasts <- fs::dir_ls("forecasts", recurse = TRUE, type = "file")
+
+
+filter_theme <- function(x, theme) {
+  x <- x[grepl(paste0(theme, "-"), x)]
+  x <- x[!stringr::str_detect(x, "xml")]
+  x <- x[!stringr::str_detect(x, "not_in_standard")]
+  x
+ }
+filter_prov <- function(x, prov_tsv){
+        if(!file.exists(prov_tsv)) return(x)
+        prov <- read_tsv(prov_tsv)
+        ids <- contentid::content_id(x)
+        keep <- !(ids %in% prov$id)
+        x[keep]
+}
 
 ## aquatics
-targets_file <- targets[grepl("aquatics-targets", targets)]
-forecast_files <- forecasts[grepl("aquatics-", forecasts)]
-forecast_files <- forecast_files[!stringr::str_detect(forecast_files, "xml")]
-forecast_files <- forecast_files[!stringr::str_detect(forecast_files, "not_in_standard")]
-score_files <- neon4cast:::score_it(targets_file, forecast_files,
+targets_file <- filter_theme(targets, "aquatics")
+forecast_files <- filter_theme(forecasts, "aquatics") %>%
+  filter_prov( "scores/aquatics/prov.tsv")
+
+if(length(forecast_files) > 0){
+        score_files <- neon4cast:::score_it(targets_file, forecast_files,
          target_variables = c("oxygen", "temperature"))
 
 ## Publish
-publish(code = c("R/download_bucket.R"),
-        data_in = c(targets_file, forecast_files),
+publish(data_in = c(targets_file, forecast_files),
         data_out = score_files,
         prefix = "aquatics/",
         bucket = "scores",
         registries = "https://hash-archive.carlboettiger.info")
-
+}
 
 ## beetles
-targets_file <- targets[grepl("beetles-", targets)]
-forecast_files <- forecasts[grepl("beetles-", forecasts)]
-forecast_files <- forecast_files[!stringr::str_detect(forecast_files, "xml")]
-forecast_files <- forecast_files[!stringr::str_detect(forecast_files, "not_in_standard")]
-score_files <- neon4cast:::score_it(targets_file, forecast_files,
+targets_file <- filter_theme(targets, "beetles")
+forecast_files <- filter_theme(forecasts, "beetles") %>%
+        filter_prov("scores/beetles/prov.tsv")
+
+if(length(forecast_files) > 0){
+  score_files <- neon4cast:::score_it(targets_file, forecast_files,
                        target_variables = c("richness", "abundance"),
                        )
 
-publish(code = c("R/download_bucket.R"),
-        data_in = c(targets_file, forecast_files),
+  publish(data_in = c(targets_file, forecast_files),
         data_out = score_files,
         prefix = "beetles/",
         bucket = "scores",
         registries = "https://hash-archive.carlboettiger.info")
-
+}
 
 ## terrestrial
-targets_file <- targets[grepl("terrestrial_daily-", targets)]
-forecast_files <- forecasts[grepl("terrestrial_daily-", forecasts)]
-forecast_files <- forecast_files[!stringr::str_detect(forecast_files, "xml")]
-forecast_files <- forecast_files[!stringr::str_detect(forecast_files, "not_in_standard")]
-score_files <- neon4cast:::score_it(targets_file, forecast_files,
+targets_file <- filter_theme(targets, "terrestrial_daily")
+forecast_files <- filter_theme(forecasts, "terrestrial_daily") %>%
+        filter_prov("scores/terrestrial/prov.tsv")
+
+if(length(forecast_files) > 0){
+        score_files <- neon4cast:::score_it(targets_file, forecast_files,
                         target_variables = c("nee", "le", "vswc"))
 
-publish(code = c("R/download_bucket.R"),
-        data_in = c(targets_file, forecast_files),
+publish(data_in = c(targets_file, forecast_files),
         data_out = score_files,
         prefix = "terrestrial/",
         bucket = "scores",
         registries = "https://hash-archive.carlboettiger.info")
+}
 
 ## terrestrial
-targets_file <- targets[grepl("terrestrial_30min-", targets)]
-forecast_files <- forecasts[grepl("terrestrial_30min-", forecasts)]
-forecast_files <- forecast_files[!stringr::str_detect(forecast_files, "xml")]
-forecast_files <- forecast_files[!stringr::str_detect(forecast_files, "not_in_standard")]
-score_files <- neon4cast:::score_it(targets_file, forecast_files,
+targets_file <- filter_theme(targets, "terrestrial_30min")
+forecast_files <- filter_theme(forecasts, "terrestrial_30min") %>%
+        filter_prov("scores/terrestrial/prov.tsv")
+
+if(length(forecast_files) > 0){
+        score_files <- neon4cast:::score_it(targets_file, forecast_files,
                         target_variables = c("nee", "le", "vswc"))
 
-publish(code = c("R/download_bucket.R"),
-        data_in = c(targets_file, forecast_files),
+publish(data_in = c(targets_file, forecast_files),
         data_out = score_files,
         prefix = "terrestrial/",
         bucket = "scores",
         registries = "https://hash-archive.carlboettiger.info")
-
+}
 
 ## phenology
-targets_file <- targets[grepl("phenology-", targets)]
-forecast_files <- forecasts[grepl("phenology-", forecasts)]
-forecast_files <- forecast_files[!stringr::str_detect(forecast_files, "xml")]
-forecast_files <- forecast_files[!stringr::str_detect(forecast_files, "not_in_standard")]
-score_files <- neon4cast:::score_it(targets_file, forecast_files,
+
+
+targets_file <- filter_theme(targets, "phenology")
+forecast_files <- filter_theme(forecasts, "phenology") %>%
+        filter_prov("scores/phenology/prov.tsv")
+
+if(length(forecast_files) > 0){
+        score_files <- neon4cast:::score_it(targets_file, forecast_files,
                         target_variables = c("gcc_90", "rcc_90"))
 
-publish(code = c("R/download_bucket.R"),
-        data_in = c(targets_file, forecast_files),
+publish(data_in = c(targets_file, forecast_files),
         data_out = score_files,
         prefix = "phenology/",
         bucket = "scores",
         registries = "https://hash-archive.carlboettiger.info")
+}
+
 
 ## ticks
-targets_file <- targets[grepl("ticks-", targets)]
-forecast_files <- forecasts[grepl("ticks-", forecasts)]
-forecast_files <- forecast_files[!stringr::str_detect(forecast_files, "xml")]
-forecast_files <- forecast_files[!stringr::str_detect(forecast_files, "not_in_standard")]
-score_files <- neon4cast:::score_it(targets_file, forecast_files,
+targets_file <- filter_theme(targets, "ticks")
+forecast_files <- filter_theme(forecasts, "ticks") %>%
+        filter_prov("scores/ticks/prov.tsv")
+
+if(length(forecast_files) > 0){
+  score_files <- neon4cast:::score_it(targets_file, forecast_files,
                         target_variables = c("ixodes_scapularis", "amblyomma_americanum"),
                         grouping_variables = c("time","siteID"))
 
-publish(code = c("R/download_bucket.R"),
-        data_in = c(targets_file, forecast_files),
+  publish(data_in = c(targets_file, forecast_files),
         data_out = score_files,
         prefix = "ticks/",
         bucket = "scores",
         registries = "https://hash-archive.carlboettiger.info")
 
-
+}
 
 

--- a/scoring.R
+++ b/scoring.R
@@ -27,11 +27,18 @@ filter_theme <- function(x, theme) {
   x <- x[!stringr::str_detect(x, "xml")]
   x <- x[!stringr::str_detect(x, "not_in_standard")]
   x
- }
-filter_prov <- function(x, prov_tsv){
+}
+library(contentid)
+filter_prov <- function(x, prov_tsv, target){
+  
         if(!file.exists(prov_tsv)) return(x)
         prov <- read_tsv(prov_tsv)
-        ids <- contentid::content_id(x)
+        
+        new_target <- !(content_id(target) %in% prov$id)
+        if(new_target) return(x)
+          
+        
+        ids <- content_id(x)
         keep <- !(ids %in% prov$id)
         x[keep]
 }
@@ -39,7 +46,7 @@ filter_prov <- function(x, prov_tsv){
 ## aquatics
 targets_file <- filter_theme(targets, "aquatics")
 forecast_files <- filter_theme(forecasts, "aquatics") %>%
-  filter_prov( "scores/aquatics/prov.tsv")
+  filter_prov( "scores/aquatics/prov.tsv", targets_file)
 
 if(length(forecast_files) > 0){
         score_files <- neon4cast:::score_it(targets_file, forecast_files,
@@ -56,7 +63,7 @@ publish(data_in = c(targets_file, forecast_files),
 ## beetles
 targets_file <- filter_theme(targets, "beetles")
 forecast_files <- filter_theme(forecasts, "beetles") %>%
-        filter_prov("scores/beetles/prov.tsv")
+        filter_prov("scores/beetles/prov.tsv", targets_file)
 
 if(length(forecast_files) > 0){
   score_files <- neon4cast:::score_it(targets_file, forecast_files,
@@ -73,7 +80,7 @@ if(length(forecast_files) > 0){
 ## terrestrial
 targets_file <- filter_theme(targets, "terrestrial_daily")
 forecast_files <- filter_theme(forecasts, "terrestrial_daily") %>%
-        filter_prov("scores/terrestrial/prov.tsv")
+        filter_prov("scores/terrestrial/prov.tsv", targets_file)
 
 if(length(forecast_files) > 0){
         score_files <- neon4cast:::score_it(targets_file, forecast_files,
@@ -89,7 +96,7 @@ publish(data_in = c(targets_file, forecast_files),
 ## terrestrial
 targets_file <- filter_theme(targets, "terrestrial_30min")
 forecast_files <- filter_theme(forecasts, "terrestrial_30min") %>%
-        filter_prov("scores/terrestrial/prov.tsv")
+        filter_prov("scores/terrestrial/prov.tsv", targets_file)
 
 if(length(forecast_files) > 0){
         score_files <- neon4cast:::score_it(targets_file, forecast_files,
@@ -107,7 +114,7 @@ publish(data_in = c(targets_file, forecast_files),
 
 targets_file <- filter_theme(targets, "phenology")
 forecast_files <- filter_theme(forecasts, "phenology") %>%
-        filter_prov("scores/phenology/prov.tsv")
+        filter_prov("scores/phenology/prov.tsv", targets_file)
 
 if(length(forecast_files) > 0){
         score_files <- neon4cast:::score_it(targets_file, forecast_files,
@@ -124,7 +131,7 @@ publish(data_in = c(targets_file, forecast_files),
 ## ticks
 targets_file <- filter_theme(targets, "ticks")
 forecast_files <- filter_theme(forecasts, "ticks") %>%
-        filter_prov("scores/ticks/prov.tsv")
+        filter_prov("scores/ticks/prov.tsv", targets_file)
 
 if(length(forecast_files) > 0){
   score_files <- neon4cast:::score_it(targets_file, forecast_files,


### PR DESCRIPTION
@rqthomas this adds filtering based on provenance: if a forecast's content-id matches that of one in the provenance record for scoring, we can assume we have already scored it, and thus not score it again.  Note that if someone updates a forecast (i.e. fixes an error in a previous version without changing the filename of the submission), this ensures that a new score will be computed.

This pull request uses a simple `tsv` file for provenance, which is append-friendly and just much faster than JSON-LD.  The prov metadata recorded in this tsv format (using `prov::write_prov_tsv()`)  isn't quite as rich, and it's just in a somewhat arbitrary table now and not in the DCAT(2) standard, but it serves the purpose well.  Note: this needs the latest version of `cboettig/prov` installed from GitHub. 

I also took the liberty of replacing `download_bucket` with `aws.s3::s3sync`, which only downloads from the bucket those files whose md5sums differ.  This should speed that step up considerably, particularly as some of the buckets are getting big.  

With these three changes (scoring only new forecasts, faster prov management, faster download), the whole script should run nearly instantaneously if no files have changed, and be quite fast in scoring new/updated submissions.  